### PR TITLE
smaller screenshoots side-by-side, onclick: open in new tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ rivus is a [mixed integer linear programming](https://en.wikipedia.org/wiki/Inte
 
 ## Screenshots
 
-<a href="doc/img/caps-elec.png"><img src="doc/img/caps-elec.png" alt="Electricity network capacities" style="width:400px"></a>
-<a href="doc/img/caps-heat.png"><img src="doc/img/caps-heat.png" alt="Heat network capacities" style="width:400px"></a>
-<a href="doc/img/caps-gas.png"><img src="doc/img/caps-gas.png" alt="Gas network capacities" style="width:400px"></a>
+Electricity network capacities|  Heat network capacities    |  Gas network capacities
+:----------------------------:|:---------------------------:|:---------------------------:
+![](doc/img/caps-elec.png)    |  ![](doc/img/caps-heat.png) |  ![](doc/img/caps-gas.png)
 
 ## Installation
 


### PR DESCRIPTION
Just a little suggestion/enhancement.
_Should be merged before #17 _ 
Pro: 
+ See side-by-side the results (comparison)
+ No need to scroll so much for the other information
+ Pictures open up in new tab

Con:
- Table borders
- Fewer details on the fist look (but I do not think this is the place for in-depth comparison)

![image](https://user-images.githubusercontent.com/15908859/27768531-904f9662-5f16-11e7-8a3c-f91a2360b68d.png)
