### PR TITLE
EXCEL ranges. Added ranges to excel parsing, if a range was well defined

### DIFF
--- a/rivus/main/rivus.py
+++ b/rivus/main/rivus.py
@@ -75,13 +75,19 @@ def read_excel(filename):
         a dict of 6 DataFrames, one for each sheet
     """
     with pd.ExcelFile(filename) as xls:
-        commodity = xls.parse('Commodity').set_index(['Commodity'])
-        process = xls.parse('Process').set_index(['Process'])
-        time = xls.parse('Time').set_index(['Time'])
-        area_demand = xls.parse('Area-Demand').set_index(['Area', 'Commodity'])
+        commodity = (
+            xls.parse('Commodity', parse_cols='A:J')
+               .set_index(['Commodity']))
+        process = (
+            xls.parse('Process', parse_cols='A:G')
+               .set_index(['Process']))
         process_commodity = (
-            xls.parse('Process-Commodity')
+            xls.parse('Process-Commodity', parse_cols='A:D')
                .set_index(['Process', 'Commodity', 'Direction']))
+        area_demand = (
+            xls.parse('Area-Demand', parse_cols='A:C')
+               .set_index(['Area', 'Commodity']))
+        time = xls.parse('Time').set_index(['Time'])
 
     data = {
         'commodity': commodity,


### PR DESCRIPTION
I noticed that in rivus.py `read_excel()` imports the empty column and the comment column from the `process` sheet.  (empty column as 'Unnamed' series with N/A values)
That unused data was misleading during the development of rivus-->DB process.
That is why I added well-defined ranges ('A:J') during the import process as implemented in [`df.read_excel()`](https://pandas.pydata.org/pandas-docs/stable/generated/pandas.read_excel.html)

The `Time` sheet does not have a trivially identifiable range, so it is left as it is.