### PR TITLE
Handle possible -too clever- indexing of input geoDFs

### DIFF
--- a/rivus/main/rivus.py
+++ b/rivus/main/rivus.py
@@ -123,6 +123,16 @@ def create_model(data, vertex, edge, peak_multiplier=None):
     time = data['time']
     area_demand = data['area_demand']
 
+    # Handling the indexing of GeoDataFrames
+    # If we get "too clever" input,
+    # reset it to leave peak calculation untouched.
+    # If not, peak gets messed up through
+    # edge_areas and multiply_by_area_demand
+    if edge.index.names == ['Vertex1', 'Vertex2']:
+        edge = edge.reset_index()
+    if vertex.index.names == ['Vertex']:
+        vertex = vertex.reset_index()
+
     # process input/output ratios
     m.r_in = process_commodity.xs('In', level='Direction')['ratio']
     m.r_out = process_commodity.xs('Out', level='Direction')['ratio']


### PR DESCRIPTION
As for now create_model awaits 'unindexed' geoDFs and does the indexing later internally.
If the inputs are already indexed, things get messed up around m.peak calculation.
(Instead of Vertex1-Vertex2  only Vertex2 will be assigned as an index to m.peak.  Which of course is incorrect for edge look up)