### PR TITLE
Add nicer docstings, pep8 variable names

### DIFF
--- a/rivus/graph/to_graph.py
+++ b/rivus/graph/to_graph.py
@@ -135,13 +135,14 @@ def to_nx(vdf, edf, pmax, comms=None, save_dir=None):
     Example
     -------
     ::
+
         _, pmax, _, _ = get_constants(prob)
         graphs = to_nx(vertex, edge, pmax, ['Gas', 'Heat'])
 
     Note
     ----
-    nx.from_pandas_dataframe() was also investigated for conversion, but it is a bit
-    slower and does not improve code quality in my opinion.
+    ``nx.from_pandas_dataframe()`` was also investigated for conversion,
+    but it is a bit slower and does not improve code quality in my opinion.
     """
     import networkx as nx
     comms = pmax.columns.values if comms is None else comms

--- a/rivus/graph/to_graph.py
+++ b/rivus/graph/to_graph.py
@@ -47,6 +47,7 @@ def to_igraph(vdf, edf, pmax, comms=None, peak=None, save_dir=None, ext='gml'):
     Example
     -------
     ::
+
         _, pmax, _, _ = get_constants(prob)
         graphs = to_igraph(vertex, edge, pmax, ['Gas', 'Heat'])
     """

--- a/rivus/gridder/extend_grid.py
+++ b/rivus/gridder/extend_grid.py
@@ -23,18 +23,20 @@ def vert_init_commodities(vertex_df, commodities, sources=None, inplace=True):
     Returns
     -------
     None or DataFrame
-        DataFrame if inplace is False
+        DataFrame if inplace == False
 
     Raises
     ------
     ValueError
-    If parameters differ from awaited
+        If parameters differ from awaited
 
-    Usage
-    -----
-    comms = ('Elec', 'Gas')
-    sources = [('Elec', 0, 1000), ('Gas', 1, 500)]
-    vert_init_commodities(vert, comms, sources)
+    Example
+    --------
+    ::
+
+        comms = ('Elec', 'Gas')
+        sources = [('Elec', 0, 1000), ('Gas', 1, 500)]
+        vert_init_commodities(vert, comms, sources)
     """
     if inplace:
         vdf = vertex_df
@@ -74,29 +76,34 @@ def extend_edge_data(edge_df, sorts=None, inits=None, strat='equal',
     inits : list of int/float , optional
         The parameter values, matching to sorts argument.
         Defaults to [1000] for each sort.
-    strat : str, optional [TODO now only 'equal' has an effect]
+    strat : str, optional
+        **TODO now only 'equal' has an effect**
         How the data values will be created
         + 'equal' - all edge demand is the same
         + 'linear' - linearly decreasing
         + 'exp' - exponentially decreasing
         + 'manual' - provide mapper in strat_param
-    strat_param : optional [TODO no implemented yet]
+    strat_param : optional
+        **TODO not implemented yet**
         Parameter for linear | exp | manual strategies.
         + 'equal' - None - no effect
         + 'linear' - minimum (lowest demand)
         + 'exp' - minimum (lowest demand)
         + 'manual' - function/dict to fetch value per edge
 
+    Example
+    -------
+    ::
+
+        sorts = ('residential', 'other')
+        inits = (1000, 800)
+        extend_edge_data(edge, sorts=sorts, inits=inits)
+
     Raises
     ------
     ValueError
-    If inputs differ from awaited
+        If inputs differ from awaited
 
-    Usage
-    -----
-    sorts = ('residential', 'other')
-    inits = (1000, 800)
-    extend_edge_data(edge, sorts=sorts, inits=inits)
     """
 
     # How the data will be distributed among the edges

--- a/rivus/utils/notify.py
+++ b/rivus/utils/notify.py
@@ -31,6 +31,29 @@ def email_me(message, sender, send_pass, recipient, smtp_addr, smtp_port,
     integer
         0  - if run through without exception
         -1 - if encountered with a problem (mainly for unittest)
+
+    Example
+    -------
+    ::
+
+        email_setup = {
+            'sender': config['email']['s_user'],
+            'send_pass': config['email']['s_pass'],
+            'recipient': config['email']['r_user'],
+            'smtp_addr': config['email']['smtp_addr'],
+            'smtp_port': config['email']['smtp_port']}
+        ...
+        except Exception as solve_error:
+            sub = run_summary + '[rivus][solve-error]'
+            email_me(solve_error, subject=sub, **email_setup)
+
+        # or with traceback:
+
+        except Exception as plot_error:
+            err_tb = tb.format_exception(
+                        None, plot_error, plot_error.__traceback__)
+            sub = run_summary + '[rivus][plot-error]'
+            email_me(err_tb, subject=sub, **email_setup)
     """
     smtp_msg = MIMEMultipart()
     smtp_msg['From'] = sender

--- a/rivus/utils/prerun.py
+++ b/rivus/utils/prerun.py
@@ -1,8 +1,10 @@
 """Collection of small rivus related helper functions
 
 In use to avoid multiple solutions of the same task, like:
-    + Setting up the solver.
-    - Todo: Create needed directories
+
++ Setting up the solver.
++ Todo: Create needed directories
+
 """
 from multiprocessing import cpu_count
 
@@ -12,25 +14,44 @@ def setup_solver(optim, logfile='solver.log', guro_time_lim=12000,
                  log_to_console=True):
     """Change solver options to custom values.
 
-    Args:
-        optim: (pyomo Solver object): See usage for example
-        logfile (str, optional): default='solver.log'
-            Name (Path) to the logfile
-        guro_time_lim (int, optional): unit is seconds | default=12000
-        guro_mip_focus (int, optional): default=2
-            1=feasible, 2=optimal, 3=bound
-        guro_mip_gap (float, optional): our default=.001
-            (gurobi's default: 1e-4)
-        guro_threads (None, optional): parallel solver tasks | default=None
-            If None, no Threads parameter is set
-                (gurobi takes <=CPU_count threads automatically)
-            If greater than CPU_count then it is threshold to CPU_count
-            If less than CPU_count then Thread is set with the parameter
-        log_to_console (Boolean, optional) If False, the output of the solver
-            is not piped to the stdout.
-    Usage:
+    Parameters
+    ----------
+    optim : SolverFactory
+        pyomo Solver object from pyomo.opt.base
+    logfile : str, optional
+        default='solver.log'
+        Name (Path) to the logfile
+    guro_time_lim : int, optional
+        unit is seconds | default=12000
+    guro_mip_focus : int, optional
+        default=2
+        1=feasible, 2=optimal, 3=bound
+    guro_mip_gap : float, optional
+        our default=.001
+        (gurobi's default: 1e-4)
+    guro_threads : None, optional
+        parallel solver tasks | default=None
+        If None, no Threads parameter is set
+        (gurobi takes <=CPU_count threads automatically)
+        If greater than CPU_count then it is threshold to CPU_count
+        If less than CPU_count then Thread is set with the parameter
+    log_to_console : bool, optional
+        Description
+    log_to_console (Boolean, optional) If False, the output of the solver
+        is not piped to the stdout.
+
+    Example
+    -------
+    ::
+
+
         optim = SolverFactory('glpk')
         optim = setup_solver(optim, logfile=log_filename)
+
+    Returns
+    -------
+    SolverFactory
+        With applied modifications
     """
     if optim.name == 'gurobi':
         # reference with list of option names

--- a/rivus/utils/runmany.py
+++ b/rivus/utils/runmany.py
@@ -7,6 +7,7 @@ from numpy import arange
 def parameter_range(data_df, index, column, lim_lo=None, lim_up=None,
                     step=None, zero_root=None):
     """Yield values of the parameter in a given range
+
     Parameters
     ----------
     data_df : DataFrame
@@ -29,10 +30,30 @@ def parameter_range(data_df, index, column, lim_lo=None, lim_up=None,
         proportions will fail.
         Use this value to set the root for the parameter range.
 
-    Returns
-    -------
+    Yields
+    ------
     DataFrame
         A modified version of xls[df_name]
+
+    Example
+    --------
+    ::
+
+        data = read_excel(data_spreadsheet)
+        interesting_parameters = [
+            {'df_name': 'commodity',
+             'args': {'index': 'Heat',
+                      'column': 'cost-inv-fix',
+                      'lim_lo': 0.5, 'lim_up': 1.6, 'step': 0.5}},
+            {'df_name': 'commodity',
+             'args': {'index': 'Heat',
+                      'column': 'cost-fix',
+                      'lim_lo': 0.5, 'lim_up': 1.6, 'step': 0.5}}]
+        for param in interesting_parameters :
+            sheet = data[param['df_name']]
+            param_path = param['args']
+            for variant in parameter_range(sheet, **param_path):
+                ...
     """
     df = data_df.copy()  # Leave the original untouched
     is_multi = len(df.index.names) > 1


### PR DESCRIPTION
Somehow this commit was not included at the time of the bigger merge process.
The docstring modifications enable nice display on readthedocs and the variable names are now all in `snake_case`