### PR TITLE
Update pmax in get_constants

### DIFF
--- a/rivus/main/rivus.py
+++ b/rivus/main/rivus.py
@@ -907,6 +907,11 @@ def get_constants(prob):
     Kappa_hub = Kappa_hub[Kappa_hub > 0].unstack().fillna(0)
     Kappa_process = Kappa_process[Kappa_process > 0].unstack().fillna(0)
 
+    # Drop all 0 commodities
+    for column in Pmax:
+        if all(Pmax[column] == 0):
+            del Pmax[column]
+
     # round to integers
     if Pmax.empty:
         Pmax = pd.DataFrame([])


### PR DESCRIPTION
Do not return commodities in the pmax (built commodities) dataframe which were not build out at all.